### PR TITLE
REST: upgrade spring-hateos dependency.

### DIFF
--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.springframework.hateoas</groupId>
 			<artifactId>spring-hateoas</artifactId>
-			<version>0.2.0.BUILD-SNAPSHOT</version>
+			<version>0.3.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		
 		<!-- Spring -->


### PR DESCRIPTION
Upgrade dependency spring-hateos 0.{2,3}.0.BUILD-SNAPSHOT.
This fixes the ClassNotFoundException for o.s.h.ResourceProcessor on
jetty startup.

Doing the usual 'mvn clean install jetty:run -(Dspring.profiles.active=with-data)' against a clean checkout of the the source in the rest sub project yields an exception[1] on multiple OS/JDK setups.

Upgrading spring-hateos to 0.2.0.RELEASE doesn't help, but for me it works with the 0.3.0.BUILD-SNAPSHOT. I didn't bother investigating any further at this point as it's probably not needed. Let me know if you do need more info though.

[1]
https://github.com/jotomo/clipboard/blob/master/spring-data-book-rest_stacktrace_spring_hateoas_0.2.0.BUILD-SNAPSHOT.txt
