### PR TITLE
Broken dependency for maven-apt-plugin

### DIFF
--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -64,8 +64,8 @@
         <plugins>
             <plugin>
                 <groupId>com.mysema.maven</groupId>
-                <artifactId>maven-apt-plugin</artifactId>
-                <version>1.0.4</version>
+                <artifactId>apt-maven-plugin</artifactId>
+                <version>1.0.7</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.mysema.querydsl</groupId>


### PR DESCRIPTION
Hi,
Changed from maven-apt-plugin v 1.05 to apt-maven-plugin and v1.0.7.  Would build but tests would fail because of missing classes.
Looks like v1.0.8 will be next up but it hasn't made it to repositories yet.
