### PR TITLE
URL Cleanup

### DIFF
--- a/gemfire/pom.xml
+++ b/gemfire/pom.xml
@@ -49,7 +49,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestones</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/hadoop/batch-extract/pom.xml
+++ b/hadoop/batch-extract/pom.xml
@@ -206,7 +206,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/batch-import/pom.xml
+++ b/hadoop/batch-import/pom.xml
@@ -206,7 +206,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/batch-wordcount/pom.xml
+++ b/hadoop/batch-wordcount/pom.xml
@@ -156,7 +156,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/file-polling/pom.xml
+++ b/hadoop/file-polling/pom.xml
@@ -61,7 +61,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/ftp/pom.xml
+++ b/hadoop/ftp/pom.xml
@@ -76,7 +76,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/hbase/pom.xml
+++ b/hadoop/hbase/pom.xml
@@ -79,7 +79,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/hive/pom.xml
+++ b/hadoop/hive/pom.xml
@@ -189,7 +189,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/pig/pom.xml
+++ b/hadoop/pig/pom.xml
@@ -115,7 +115,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/scheduling-quartz/pom.xml
+++ b/hadoop/scheduling-quartz/pom.xml
@@ -83,7 +83,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/scheduling/pom.xml
+++ b/hadoop/scheduling/pom.xml
@@ -62,7 +62,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/streaming/pom.xml
+++ b/hadoop/streaming/pom.xml
@@ -129,7 +129,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/wordcount-hdfs-copy/pom.xml
+++ b/hadoop/wordcount-hdfs-copy/pom.xml
@@ -69,7 +69,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/wordcount-spring-basic/pom.xml
+++ b/hadoop/wordcount-spring-basic/pom.xml
@@ -62,7 +62,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hadoop/wordcount-spring-intermediate/pom.xml
+++ b/hadoop/wordcount-spring-intermediate/pom.xml
@@ -63,7 +63,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -100,7 +100,7 @@
 	<repositories>
 		<repository>
 			<id>neo4j-public-release-repository</id>
-			<url>http://m2.neo4j.org/releases</url>
+			<url>https://m2.neo4j.org/releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -49,7 +49,7 @@
 	<repositories>
 		<repository>
 			<id>spring-releases</id>
-			<url>http://repo.springsource.org/libs-release</url>
+			<url>https://repo.springsource.org/libs-release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -120,7 +120,7 @@
 	<repositories>
 		<repository>
 			<id>spring-libs-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/roo/roo-spring-data-jpa/pom.xml
+++ b/roo/roo-spring-data-jpa/pom.xml
@@ -18,12 +18,12 @@
         <repository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </repository>
         <repository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
         <repository>
             <id>spring-roo-repository</id>
@@ -35,12 +35,12 @@
         <pluginRepository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </pluginRepository>
         <pluginRepository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </pluginRepository>
         <pluginRepository>
             <id>spring-roo-repository</id>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://spring-roo-repository.springsource.org/release (404) migrated to:  
  http://spring-roo-repository.springsource.org/release ([https](https://spring-roo-repository.springsource.org/release) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://m2.neo4j.org/releases (404) migrated to:  
  https://m2.neo4j.org/releases ([https](https://m2.neo4j.org/releases) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-release migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance